### PR TITLE
Fix lint errors

### DIFF
--- a/src-rs/lib.rs
+++ b/src-rs/lib.rs
@@ -7,7 +7,6 @@ mod swift_arg;
 mod swift_ret;
 mod types;
 
-pub use autorelease::*;
 pub use swift::*;
 pub use swift_arg::*;
 pub use swift_ret::*;

--- a/src-rs/lib.rs
+++ b/src-rs/lib.rs
@@ -17,4 +17,3 @@ pub use types::*;
 mod build;
 #[cfg(feature = "build")]
 pub use build::*;
-

--- a/src-rs/lib.rs
+++ b/src-rs/lib.rs
@@ -17,3 +17,4 @@ pub use types::*;
 mod build;
 #[cfg(feature = "build")]
 pub use build::*;
+

--- a/src-rs/swift.rs
+++ b/src-rs/swift.rs
@@ -31,7 +31,7 @@ pub trait SwiftObject {
     /// The inner pointer is private,
     /// and the returned [`SwiftRef`] is bound to the lifetime of the original [`SRObject`],
     /// so if you use `swift-rs` as normal this function should be safe.
-    unsafe fn swift_ref(&self) -> SwiftRef<Self>
+    unsafe fn swift_ref(&self) -> SwiftRef<'_, Self>
     where
         Self: Sized,
     {


### PR DESCRIPTION
### What
Fix an error in CI.

For the `SwiftRef<'_, Self>` fix, the explanation is:
> The Clippy warning "hiding a lifetime that's elided elsewhere is confusing" is caused by a mismatch in how lifetimes are specified in the swift_ref function signature. The 'a lifetime in SwiftRef<'a, Self> is explicitly named, while the lifetime of the &self receiver is elided (omitted). To fix this, you need to use a consistent lifetime syntax.
> 
> Fixing the Mismatched Lifetimes
> The simplest and most recommended fix is to use the anonymous lifetime placeholder '_ for the return type, mirroring the elided lifetime of &self.
> - `unsafe fn swift_ref(&self) -> SwiftRef<'_, Self>`
> 
> Alternatively, you could explicitly name the lifetime for both the receiver and the return type.
> - `unsafe fn swift_ref<'a>(&'a self) -> SwiftRef<'a, Self>`
> 
> Both of these solutions resolve the inconsistency that Clippy warns about. The first option is generally preferred as it's more concise and aligns with the typical way Rust handles elided lifetimes.

### Testing
Before:
```
~/repo/swift-rs cargo +beta clippy -- -D warnings                                                clean 
    Checking swift-rs v1.0.7 (/Users/paris/repo/swift-rs)
error: unused import: `autorelease::*`
  --> src-rs/lib.rs:10:9
   |
10 | pub use autorelease::*;
   |         ^^^^^^^^^^^^^^
   |
   = note: `-D unused-imports` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_imports)]`

error: hiding a lifetime that's elided elsewhere is confusing
  --> src-rs/swift.rs:34:25
   |
34 |     unsafe fn swift_ref(&self) -> SwiftRef<Self>
   |                         ^^^^^     -------------- the same lifetime is hidden here
   |                         |
   |                         the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `-D mismatched-lifetime-syntaxes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(mismatched_lifetime_syntaxes)]`
help: use `'_` for type paths
   |
34 |     unsafe fn swift_ref(&self) -> SwiftRef<'_, Self>
   |                                            +++

error: could not compile `swift-rs` (lib) due to 2 previous errors
```

After:
```
~/repo/swift-rs cargo +beta clippy -- -D warnings                                                 main 
   Compiling proc-macro2 v1.0.95
   Compiling unicode-ident v1.0.18
   Compiling serde v1.0.219
   Compiling serde_json v1.0.142
   Compiling ryu v1.0.20
   Compiling itoa v1.0.15
   Compiling memchr v2.7.5
    Checking base64 v0.21.7
   Compiling quote v1.0.40
   Compiling syn v2.0.104
   Compiling serde_derive v1.0.219
   Compiling swift-rs v1.0.7 (/Users/paris/repo/swift-rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.56s
```