### PR TITLE
Disable sandboxing of Swift build to fix errors when building in a Bazel sandbox

### DIFF
--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -302,6 +302,10 @@ impl SwiftLinker {
             command
                 // Build the package (duh)
                 .arg("build")
+                // NOTE(paris): Disable the sandbox because we build inside the Bazel sandbox, which 
+                // has its own sandbox. Without this we fail with:
+                // - `sandbox-exec: sandbox_apply: Operation not permitted`
+                .arg("--disable-sandbox")
                 // SDK path for regular compilation (idk)
                 .args(["--sdk", sdk_path.trim()])
                 // Release/Debug configuration

--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -302,7 +302,7 @@ impl SwiftLinker {
             command
                 // Build the package (duh)
                 .arg("build")
-                // NOTE(paris): Disable the sandbox because we build inside the Bazel sandbox, which 
+                // NOTE(paris): Disable the sandbox because we build inside the Bazel sandbox, which
                 // has its own sandbox. Without this we fail with:
                 // - `sandbox-exec: sandbox_apply: Operation not permitted`
                 .arg("--disable-sandbox")


### PR DESCRIPTION
### What
When writing a Bazel rule to build Tauri in a sandbox, we get:
```
error: 'ios-api': Invalid manifest (compiled with: ["/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc", "-vfsoverlay", "/private/var/tmp/_bazel_paris/dba729e604a09d9c62052df799e28ca4/sandbox/darwin-sandbox/1011/execroot/_main/tmp/TemporaryDirectory.xzsTw9/vfs.yaml", "-L", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI", "-lPackageDescription", "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI", "-target", "arm64-apple-macosx14.0", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk", "-F", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks", "-F", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/PrivateFrameworks", "-I", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib", "-L", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/usr/lib", "-swift-version", "5", "-I", "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/pm/ManifestAPI", "-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk", "-package-description-version", "5.3.0", "/private/var/tmp/_bazel_paris/dba729e604a09d9c62052df799e28ca4/sandbox/darwin-sandbox/1011/execroot/_main/c8/html-shell-tauri/src-tauri/vendor/tauri/mobile/ios-api/Package.swift", "-o", "/private/var/tmp/_bazel_paris/dba729e604a09d9c62052df799e28ca4/sandbox/darwin-sandbox/1011/execroot/_main/tmp/TemporaryDirectory.mCskJN/ios-api-manifest"])
  sandbox-exec: sandbox_apply: Operation not permitted
```

This is because SwiftPM couldn’t start its internal sandbox — because Bazel didn’t allow it access to sandbox-exec. To fix this, we disable sandboxing of SwiftPM, as it will use the Bazel sandbox instead.

Docs:
```
/repo/swift-rs swift build --help                                                                                                                                   nae-1
OVERVIEW: Build sources into binary products

SEE ALSO: swift run, swift package, swift test

USAGE: swift build <options>
...
  --disable-sandbox       Disable using the sandbox when executing subprocesses
```

### Testing
With this fix, we don't get that error and can build Tauri apps in Bazel.