### PR TITLE
Get apple sdk root from cc instead of xcrun

### DIFF
--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -293,9 +293,9 @@ impl SwiftLinker {
                 .join("swift-rs")
                 .join(&package.name);
 
-            // NOTE(paris): Fetch the SDK directly from cc because when running using hermetic 
-            // bazel, we do not have xcrun available in the xcode toolchain (it's an OSX host 
-            // library). So running it will use non-hermetic xcode toolchain and fail on CI machines 
+            // NOTE(paris): Fetch the SDK directly from cc because when running using hermetic
+            // bazel, we do not have xcrun available in the xcode toolchain (it's an OSX host
+            // library). So running it will use non-hermetic xcode toolchain and fail on CI machines
             // where it is not installed (and give incorrect paths even if it is installed).
             let sdk_path = if let Some(path) = self.sysroot_from_cc() {
                 path
@@ -312,7 +312,10 @@ impl SwiftLinker {
                     );
                 }
 
-                String::from_utf8(sdk_path_output.stdout).unwrap().trim().to_string()
+                String::from_utf8(sdk_path_output.stdout)
+                    .unwrap()
+                    .trim()
+                    .to_string()
             };
 
             let mut command = Command::new("swift");

--- a/src-rs/build.rs
+++ b/src-rs/build.rs
@@ -244,6 +244,27 @@ impl SwiftLinker {
         self
     }
 
+    // Gets the sysroot from cc by looking for the -sysroot flag. Used b/c neither SDKROOT nor
+    // SYSROOT environment variables are set when running using hermetic bazel.
+    fn sysroot_from_cc(&self) -> Option<String> {
+        let cc = std::env::var("CC").ok()?;
+        let out = Command::new(cc)
+            .args(["-v", "-E", "-"])
+            .stdin(std::process::Stdio::null())
+            .output()
+            .ok()?;
+        let s = std::str::from_utf8(&out.stderr).ok()?;
+        let mut it = s.split_whitespace();
+        while let Some(t) = it.next() {
+            if t == "-isysroot" {
+                if let Some(p) = it.next() {
+                    return Some(p.to_string());
+                }
+            }
+        }
+        None
+    }
+
     /// Links the Swift runtime, then builds and links the provided packages.
     /// This does not (yet) automatically rebuild your Swift files when they are modified,
     /// you'll need to modify/save your `build.rs` file for that.
@@ -265,25 +286,34 @@ impl SwiftLinker {
 
         link_clang_rt(&rust_target);
 
-        for package in self.packages {
+        for package in &self.packages {
             let package_path =
                 Path::new(&env::var("CARGO_MANIFEST_DIR").unwrap()).join(&package.path);
             let out_path = Path::new(&env::var("OUT_DIR").unwrap())
                 .join("swift-rs")
                 .join(&package.name);
 
-            let sdk_path_output = Command::new("xcrun")
-                .args(["--sdk", &rust_target.sdk.to_string(), "--show-sdk-path"])
-                .output()
-                .unwrap();
-            if !sdk_path_output.status.success() {
-                panic!(
-                    "Failed to get SDK path with `xcrun --sdk {} --show-sdk-path`",
-                    rust_target.sdk
-                );
-            }
+            // NOTE(paris): Fetch the SDK directly from cc because when running using hermetic 
+            // bazel, we do not have xcrun available in the xcode toolchain (it's an OSX host 
+            // library). So running it will use non-hermetic xcode toolchain and fail on CI machines 
+            // where it is not installed (and give incorrect paths even if it is installed).
+            let sdk_path = if let Some(path) = self.sysroot_from_cc() {
+                path
+            } else {
+                let sdk_path_output = Command::new("xcrun")
+                    .args(["--sdk", &rust_target.sdk.to_string(), "--show-sdk-path"])
+                    .output()
+                    .unwrap();
 
-            let sdk_path = String::from_utf8_lossy(&sdk_path_output.stdout);
+                if !sdk_path_output.status.success() {
+                    panic!(
+                        "Failed to get SDK path with `xcrun --sdk {} --show-sdk-path`",
+                        rust_target.sdk
+                    );
+                }
+
+                String::from_utf8(sdk_path_output.stdout).unwrap().trim().to_string()
+            };
 
             let mut command = Command::new("swift");
             command.current_dir(&package.path);
@@ -323,8 +353,6 @@ impl SwiftLinker {
                 .args(["-Xswiftc", &swift_target_triple])
                 .args(["-Xcc", &format!("--target={swift_target_triple}")])
                 .args(["-Xcxx", &format!("--target={swift_target_triple}")]);
-
-            println!("Command `{command:?}`");
 
             if !command.status().unwrap().success() {
                 panic!("Failed to compile swift package {}", package.name);


### PR DESCRIPTION
### What
As part of Tauri building via Bazel, this PR fixes a hermeticity bug coming from `swift-rs`. 

Specifically, `swift-rs` previously used the host machine's `xcrun` to fetch the Apple SDKs and deployment targets for iOS and OSX. The issue is that `xcrun` is a host-machine binary which points `cc-rs` at non-hermetic XCode SDKs. This results in non-hermetic builds locally (when XCode and XCode CLI Tools have been downloaded) and failing builds on CI (when they are not present). The error you get on CI is:
```
18:01:16 cargo:rustc-check-cfg=cfg(custom_protocol)
18:01:16 cargo:rustc-check-cfg=cfg(dev)
18:01:16 cargo:rustc-cfg=dev
18:01:16 cargo:dev=true
18:01:16 cargo:rustc-check-cfg=cfg(desktop)
18:01:16 cargo:rustc-check-cfg=cfg(mobile)
18:01:16 cargo:rustc-cfg=mobile
18:01:16 cargo:rustc-link-search=native=/Library/Developer/CommandLineTools/usr/lib/swift/iphoneos
18:01:16 cargo:rustc-link-search=native=/usr/lib/swift
18:01:16 cargo:rustc-link-lib=clang_rt.ios
18:01:16 cargo:rustc-link-search=/Library/Developer/CommandLineTools/usr/lib/clang/17/lib/darwin
18:01:16 
18:01:16 --stderr:
18:01:16 thread 'main' panicked at external/tauri-deps__swift-rs-1.0.7/src-rs/build.rs:280:17:
18:01:16 Failed to get SDK path with `xcrun --sdk iphoneos --show-sdk-path`
18:01:16 stack backtrace:
18:01:16    0:        0x104dfe440 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::habbf9c4f641febb1
18:01:16    1:        0x104e3fe44 - core::fmt::write::ha36a8060c13608ea
18:01:16    2:        0x104df2f50 - std::io::Write::write_fmt::h431832c8ebcc85c9
18:01:16    3:        0x104e00b08 - std::panicking::default_hook::{{closure}}::h4aa1f60327dfff6a
18:01:16    4:        0x104e006b8 - std::panicking::default_hook::h4ebc6eb4ae179807
18:01:16    5:        0x104e01724 - std::panicking::rust_panic_with_hook::h6a84efe4dcab239c
18:01:16    6:        0x104e01150 - std::panicking::begin_panic_handler::{{closure}}::h5eef292190467fef
18:01:16    7:        0x104dfe904 - std::sys::backtrace::__rust_end_short_backtrace::hd7e7925203f20af9
18:01:16    8:        0x104e00e18 - _rust_begin_unwind
18:01:16    9:        0x104e3c5ec - core::panicking::panic_fmt::h410d3f147658259b
18:01:16   10:        0x104b3fd8c - swift_rs::build::SwiftLinker::link::hd053f7526be199c3
18:01:16   11:        0x104820d24 - tauri_utils::build::link_apple_library::hac815aff63580ece
18:01:16   12:        0x104817954 - build_script_build::main::hb40b5b63f6ea92a9
18:01:16   13:        0x10481fec8 - std::sys::backtrace::__rust_begin_short_backtrace::he90ed75a0f0964f4
18:01:16   14:        0x10481eca0 - std::rt::lang_start::{{closure}}::h7d0e1907eef4e316
18:01:16   15:        0x104de5f90 - std::rt::lang_start_internal::h9e88109c8deb8787
18:01:16   16:        0x104819b3c - _main
```

Our solution here is to use `cc`  to find the SDK path and deployment target. Feels like somewhat of a hack, but appears to work and the code is simple enough.

### Testing
I can build and run Doty run with this plus the new `rust_binary()` target on my local machine. We'll still have to see if it gets CI to pass, but it's a step in the right direction.